### PR TITLE
Use smart apostrophe in legal byline

### DIFF
--- a/_articles/legal.md
+++ b/_articles/legal.md
@@ -1,6 +1,6 @@
 ---
 title: The Legal Side of Open Source
-description: Everything you've ever wondered about the legal side of open source, and a few things you didn't.
+description: Everything you’ve ever wondered about the legal side of open source, and a few things you didn't.
 class: legal
 toc:
   why-do-people-care-so-much-about-the-legal-side-of-open-source: "Why do people care so much about the legal side of open source?"


### PR DESCRIPTION
I saw that the [legal](https://opensource.guide/legal/) article has a straight quote (`'`) so I made it curly (`’`)!

I’m not sure if there’s a Jekyll way to make this apply to any byline in the future too, if there is, that would probably be better!