### PR TITLE
Correct footer URL to github.com

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,7 +43,7 @@
     </div>
 
     <div class="border-top text-gray py-5">
-      {% octicon code height:20 class:"v-align-middle fill-gray mr-1" aria-label:code %} with {% octicon heart height:20 class:"v-align-middle fill-gray mx-1" aria-label:love %} by <a href="http://www.github.com">{% octicon mark-github height:20 class:"v-align-middle fill-gray mx-1" aria-label:GitHub %}</a> (and you!)
+      {% octicon code height:20 class:"v-align-middle fill-gray mr-1" aria-label:code %} with {% octicon heart height:20 class:"v-align-middle fill-gray mx-1" aria-label:love %} by <a href="https://github.com">{% octicon mark-github height:20 class:"v-align-middle fill-gray mx-1" aria-label:GitHub %}</a> (and you!)
     </div>
 
   </div>


### PR DESCRIPTION
This PR does two things:

1. Drop the `www.` just `github.com` (in my best JT voice).
2. Use HTTPS, not HTTP 

🤘 