### PR TITLE
Fixed typo in the link to the style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If you don't see your idea listed, and you think it fits into the goals of this 
 * **If your contribution is major,** such as a new guide, start by opening an issue first. That way, other people can weigh in on the discussion before you do any work.
 
 ## Style guide
-If you're writing content, see the [style guide](./docs/STYLEGUIDE.md) to help your prose match the rest of the Guides.
+If you're writing content, see the [style guide](./docs/styleguide.md) to help your prose match the rest of the Guides.
 
 ## Setting up your environment
 


### PR DESCRIPTION
The style guide link was uppercase which caused a 404 error.