### PR TITLE
Navbar fix

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   <div class="container-lg edged mx-auto clearfix">
     <div class="float-sm-right">
       <ul class="main-links border-left border-bottom border-sm-0 list-style-none">
-        <li class="d-inline-block border-right border-left">
+        <li class="d-inline-block border-right">
           <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
         </li>
         <li class="d-inline-block border-right">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,7 +10,7 @@
         </li>
       </ul>
     </div>
-    {% if page.type == 'article' %}
+    {% if page.toc != null %}
     <div class="float-sm-left pl-3 breadcrumb">
       <p class="my-0 py-3 py-sm-4 text-gray">
         <a href="/" class="text-gray">Open Source Guides</a>  /

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,21 @@
+<nav class="main-nav">
+  <div class="container-lg edged mx-auto clearfix">
+    <div class="float-sm-right">
+      <ul class="main-links border-left border-bottom border-sm-0 list-style-none">
+        <li class="d-inline-block border-right border-left">
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
+        </li>
+        <li class="d-inline-block border-right">
+          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
+        </li>
+      </ul>
+    </div>
+    {% if page.type == 'article' %}
+    <div class="float-sm-left pl-3 breadcrumb">
+      <p class="my-0 py-3 py-sm-4 text-gray">
+        <a href="/" class="text-gray">Open Source Guides</a>  /
+      </p>
+    </div>
+    {% endif %}
+  </div>
+</nav>

--- a/_layouts/article-alt.html
+++ b/_layouts/article-alt.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-type: article
 ---
 
 {% include nav.html %}

--- a/_layouts/article-alt.html
+++ b/_layouts/article-alt.html
@@ -1,26 +1,9 @@
 ---
 layout: default
+type: article
 ---
 
-<nav class="main-nav">
-  <div class="container-lg edged mx-auto clearfix">
-    <div class="float-sm-right">
-      <ul class="main-links border-left border-bottom border-sm-0 list-style-none">
-        <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
-        </li>
-        <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
-        </li>
-      </ul>
-    </div>
-    <div class="float-sm-left pl-3 breadcrumb">
-      <p class="my-0 py-3 py-sm-4 text-gray">
-        <a href="/" class="text-gray">Open Source Guides</a>  /
-      </p>
-    </div>
-  </div>
-</nav>
+{% include nav.html %}
 
 <header class="bg-gray-light">
   <div class="container-lg mx-auto px-3">

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,26 +1,9 @@
 ---
 layout: default
+type: article
 ---
 
-<nav class="main-nav">
-  <div class="container-lg edged mx-auto clearfix">
-    <div class="float-sm-right">
-      <ul class="main-links border-left border-bottom border-sm-0 list-style-none">
-        <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
-        </li>
-        <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
-        </li>
-      </ul>
-    </div>
-    <div class="float-sm-left pl-3 breadcrumb">
-      <p class="my-0 py-3 py-sm-4 text-gray">
-        <a href="/" class="text-gray">Open Source Guides</a>  /
-      </p>
-    </div>
-  </div>
-</nav>
+{% include nav.html %}
 
 <header class="article-header {{ page.class }} bg-gray-light">
   <div class="container-lg mx-auto px-3">

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-type: article
 ---
 
 {% include nav.html %}

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -228,3 +228,8 @@ blockquote {
 .little-illo {
   max-height: 50px;
 }
+
+// Navbar spacing fix
+nav li {
+  float: left;
+}

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -230,6 +230,9 @@ blockquote {
 }
 
 // Navbar spacing fix
+nav li:first-of-type {
+  margin-left: 0;
+}
 nav li {
-  float: left;
+  margin-left: -4px;
 }

--- a/index.html
+++ b/index.html
@@ -2,20 +2,7 @@
 layout: landing
 ---
 
-<nav class="main-nav">
-  <div class="container-lg edged mx-auto clearfix">
-    <div class="float-sm-right">
-      <ul class="main-links border-left border-bottom border-sm-0 list-style-none">
-        <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide#open-source-guides">About</a>
-        </li>
-        <li class="d-inline-block border-right">
-          <a class="d-block p-3 p-sm-4" href="https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md">Contribute</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
+{% include nav.html %}
 
 <div class="bg-gray-light">
 


### PR DESCRIPTION
Hi there,

Absolutely love the [opensource.guide](https://opensource.guide) website!
However, I noticed a very small inconsistency when navigating the website.

The position of the second item in the navbar was a little off, which was clearly visible when hovering over the `Contribute` link. Please see the embedded image below.

Setting all `li` elements in the navbar to float to the left seemed to fix the issue on all viewports. This change required me to also add an extra class `.border-left` to the first nav item `About`. (28cb5f506f3c97fb5c661cc814e84edb87ec9490)

However, this messed up the border of the navbar. Another way to address the issue is by setting a negative margin of `-4px` on the left side of each (except the first) `nav li` item. This makes the added class `.border-left` obsolete. (7a64c3fb603837e050d121604745994ca03be5ad)

To reduce duplicate code I’ve moved the navbar `<nav>` code block to `_includes/nav.html`.
To comply with the small tweak to the navbar for the article layout, a small Jekyll if-clause and a new page variable for the article layout were required. (f0bf9677ecb281256ca0f24965aab847611cc91b, 9b2db35fb883fc87af51805bd4a5289d5295ade9)

![Before vs after.](https://cloud.githubusercontent.com/assets/4174509/22945527/ccaec8b4-f2f4-11e6-8b8a-12487ba54d6c.png)

All changes were fully tested with a local Jekyll server, as described in [contributing.md](https://github.com/github/open-source-guide/blob/gh-pages/CONTRIBUTING.md).

I did my best to satisfy with the contributing guidelines. This is my first contribution to a [github.com/github](https://github.com/github) repository, so please be gentle 😄. I am open to any and all constructive feedback, and am happy to discuss the proposed changes. 