### PR TITLE
Clarify the interaction of the CC-BY license and trademark rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Our goal is for this project to reflect community best practices, so we'd love y
 
 ## Licenses
 
-Content is released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose but does not grant you any trademark permissions, so long as you note the license and give credit, such as follows:
+Content is released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose (but does not grant you any trademark permissions), so long as you note the license and give credit, such as follows:
 
 > Content based on
 > <a href="https://github.com/github/open-source-guide">github.com/github/open-source-guide</a>

--- a/notices.md
+++ b/notices.md
@@ -13,7 +13,7 @@ Running an open source project, like any human endeavor, involves uncertainty an
 
 ## Licenses
 
-Content is released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose but does not grant you any trademark permissions, so long as you note the license and give credit, such as follows:
+Content is released under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), which gives you permission to use content for almost any purpose (but does not grant you any trademark permissions), so long as you note the license and give credit, such as follows:
 
 > Content based on [github.com/github/open-source-guide](https://github.com/github/open-source-guide) used under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license.
 


### PR DESCRIPTION
This commit changes the 'but does not grant you any trademark permissions' to a parenthetical comment (an 'aside'), instead of having be part of the main sentence. With it part of the sentence, the reader may believe that 'so long as you note the license and give credit' applies to the trademark-related phrase, when in fact it relates the prior sections of the sentence.

This same sentence structure appears elsewhere in the guides so if this change is accepted the other locations will need be updated as well. I'm happy to do that and update the PR if desired.