### PR TITLE
Fix misplaced anchors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,11 +9,15 @@
     </main>
     <script src="{{ site.baseurl }}/js/vendor/anchor-js/anchor.min.js"></script>
     <script>
+      var selector = '#content h2, #content h3, #content h4, #content h5';
+
       anchors.options = {
         //visible: 'always',
         placement: 'left'
       };
-      anchors.add('#content h2, #content h3, #content h4, #content h5');
+      anchors.add(selector);
+
+      $(selector).wrapInner('<span/>');
     </script>
   </body>
 </html>


### PR DESCRIPTION
The bug occurs because of the anchor's absolute positioning and its parent's `text-align: center` CSS property. All we need is just to wrap anchor and heading text into any HTML tag.

Closes #240 