### PR TITLE
Fix border-remains-when-vertically-aligned

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="container-lg px-3 mx-auto">
 
     <div class="d-flex flex-wrap flex-items-stretch">
-      <div class="col-12 col-sm-6 mb-4 border-right">
+      <div class="col-12 col-sm-6 mb-4 col-border">
         <div class="height-full p-5">
           <img src="{{ site.baseurl }}/assets/images/illos/squirrel.svg" class="little-illo mb-3" alt="squirrel illustration">
           <h3 class="alt-h3 mb-3">Contribute</h3>

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -206,6 +206,10 @@ blockquote {
   @include breakpoint(sm) { border-bottom: none !important;}
 }
 
+.col-border {
+  @include breakpoint(sm) { border-right: 1px #e5e5e5 solid !important; }
+}
+
 .bg-gray-light {
   background-color: #F3F3F3 !important;;
 }


### PR DESCRIPTION
I fixed #249. I change the class name and set css rule. I would like to extend `.border-right` in this code. Is there any way ?

![feb-15-2017 13-00-35](https://cloud.githubusercontent.com/assets/1587053/22960120/cad6bb66-f37e-11e6-98c9-00290210bbcf.gif)
