### PR TITLE
 Improve email input user experience

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,7 @@
 
               <div class="mc-field-group col-12">
                   <label for="mce-EMAIL" class="d-none">Email Address</label>
-                  <input type="email" placeholder="Email Address" name="EMAIL" class="form-input required email d-block col-10 mx-auto py-2 px-3 mb-3" id="mce-EMAIL">
+                  <input type="email" placeholder="Email Address" name="EMAIL" class="form-input required email d-block col-10 mx-auto py-2 px-3 mb-3" id="mce-EMAIL" autocomplete="home email">
                   <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-outline">
               </div>
               <div id="mce-responses" class="clear">


### PR DESCRIPTION
I just added autocomplete attribute to improve user experience. It helps user input their address very easy. Demo is below:
![demo](https://cloud.githubusercontent.com/assets/1587053/22962363/b39ec414-f38f-11e6-84b4-df8e58f7726a.png)

### How to debug
1. Find your IP address `preferences > Network`
2. run server `bundle exec jekyll serve --watch --incremental --baseurl '' --host <Your IP>`
3. Open the link in your mobile browser.

### A real machine verification
- iOS 
  - [x] Chrome
  - [x] Safari

What do you think ?