### PR TITLE
Fix margins so that cov-image does not touch ToC button

### DIFF
--- a/assets/css/covers.scss
+++ b/assets/css/covers.scss
@@ -73,8 +73,8 @@
   @include breakpoint(md) {
     .cover-img {
       max-width: 700px;
-      margin-top: 80px;
-      margin-bottom: -90px;
+      margin-top: 100px;
+      margin-bottom: -70px;
     }
   }
 }


### PR DESCRIPTION
Before:
![2017-02-15-160206_934x403_scrot](https://cloud.githubusercontent.com/assets/2657547/22979856/1e426fc0-f398-11e6-9ef4-b3f13d68831a.png)

After:
![2017-02-15-160151_824x380_scrot](https://cloud.githubusercontent.com/assets/2657547/22979857/1e4313da-f398-11e6-9c87-a533b9e95ca9.png)
