### PR TITLE
Bundle update if check fails

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,7 +5,7 @@ export CC=gcc
 
 echo "==> Installing gem dependencies…"
 bundle check --path vendor/gems 2>&1 > /dev/null || {
-  time bundle install --binstubs bin --path vendor/gems
+  time bundle update --binstubs bin --path vendor/gems
 }
 
 echo "==> Installing node dependencies…"


### PR DESCRIPTION
After #212, `script/bootstrap` needs to run `bundle update` to grab the latest version of dependencies.