### PR TITLE
Fix nested <p> tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,9 +43,9 @@ layout: landing
             <h3 class="alt-h3 text-bold lh-condensed mb-2 text-black">
               {{ article.title }}
             </h3>
-            <p class="mb-0 text-gray">
+            <div class="mb-0 text-gray">
               {{ article.description | markdownify }}
-            </p>
+            </div>
           </div>
 
         </a>


### PR DESCRIPTION
#256 caused there to be nested `<p>` tags, causing the one with classes (`<p class="mb-0 text-gray">`) to be closed and a new paragraph to be opened without those styles applied.

Before:

<img width="453" alt="open_source_guide_-_a_community_guide_for_open_source_creators_" src="https://cloud.githubusercontent.com/assets/173/23027823/6120cda0-f41a-11e6-8047-ad93ce014707.png">

After:

<img width="456" alt="open_source_guide_-_a_community_guide_for_open_source_creators_" src="https://cloud.githubusercontent.com/assets/173/23027779/4079131e-f41a-11e6-867e-21654f3bfa34.png">
