### PR TITLE
Broken link in environment setup section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ If you're writing content, see the [style guide](./docs/styleguide.md) to help y
 
 ## Setting up your environment
 
-This site is powered by [Jekyll](jekyllrb.com). Running it on your local machine requires a working [Ruby](https://www.ruby-lang.org/en/) installation with [Bundler](http://bundler.io/).
+This site is powered by [Jekyll](https://jekyllrb.com/). Running it on your local machine requires a working [Ruby](https://www.ruby-lang.org/en/) installation with [Bundler](http://bundler.io/).
 
 Once you have that set up, run:
 


### PR DESCRIPTION
Fixed the link. It now points correctly to the Jekyll main site.

404 page 

![screen shot 2017-02-16 at 1 14 58 pm 2](https://cloud.githubusercontent.com/assets/20526900/23034505/0b6509be-f44a-11e6-8636-ff44c20b3a72.png)
before 