### PR TITLE
Fix travis on gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,9 @@ cache:
   bundler: true
   directories:
     - node_modules
+# Tell Travis to build gh-pages branch
+# https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches
+branches:
+  only:
+    - gh-pages
+    - /.*/


### PR DESCRIPTION
It looks like Travis does not trigger builds for the `gh-pages` branch by default. This adds the config [recommended here](https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches) to make it work.