### PR TITLE
Fix rendering on forks

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
     <div class="d-flex flex-wrap flex-items-stretch">
       <div class="col-12 col-sm-6 mb-4 col-border">
         <div class="height-full p-5">
-          <img src="{{ site.baseurl }}/assets/images/illos/squirrel.svg" class="little-illo mb-3" alt="squirrel illustration">
+          <img src="{{ "/assets/images/illos/squirrel.svg" | relative_url }}" class="little-illo mb-3" alt="squirrel illustration">
           <h3 class="alt-h3 mb-3">Contribute</h3>
           <p class="mb-3 p-large">
             Want to make a suggestion? This content is open source. Help us improve it.
@@ -21,7 +21,7 @@
           <div id="mc_embed_signup">
           <form action="//github.us11.list-manage.com/subscribe/post?u=9d7ced8c4bbd6c2f238673f0f&amp;id=b514344ba3" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
               <div id="mc_embed_signup_scroll">
-                <img src="{{ site.baseurl }}/assets/images/illos/bird.svg" class="little-illo mb-3" alt="bird illustration">
+                <img src="{{ "/assets/images/illos/bird.svg" | relative_url }}" class="little-illo mb-3" alt="bird illustration">
               <h3 class="alt-h3 mb-3">Subscribe to updates</h3>
 
               <div class="mc-field-group col-12">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,10 +2,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i" rel="stylesheet">
-  <link href="/assets/css/index.css" rel="stylesheet">
+  <link href="{{ "/assets/css/index.css" | relative_url }}" rel="stylesheet">
   <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-  <script src="{{ "/js/script.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/js/script.js" | relative_url }}"></script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_includes/search-result.html
+++ b/_includes/search-result.html
@@ -1,6 +1,6 @@
 <div class="border-top pt-4 my-4">
   <h2>
-    <a href="{{ include.article.url | prepend: site.baseurl }}">
+    <a href="{{ include.article.url | relative_url }}">
       {{ include.article.title }}
     </a>
   </h2>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
         {{ content }}
       </div>
     </main>
-    <script src="{{ site.baseurl }}/js/vendor/anchor-js/anchor.min.js"></script>
+    <script src="{{ "/js/vendor/anchor-js/anchor.min.js" | relative_url }}"></script>
     <script>
       var selector = '#content h2, #content h3, #content h4, #content h5';
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ layout: landing
       {% assign articles = site.articles | sort: 'order' %}
       {% for article in articles %}
       <div class="col-12 col-sm-9 mx-auto col-md-6 mt-4 mt-lg-5">
-        <a href="{{ site.baseurl }}{{ article.url }}" class="guide-cover {{ article.class }} card height-full d-block">
+        <a href="{{ article.url | relative_url }}" class="guide-cover {{ article.class }} card height-full d-block">
 
           <div class="lh-none guide-cover-img text-center pt-4">
             <img src="{{ site.baseurl }}/assets/images/illos/{{ article.class }}.svg" class="" alt="{{ article.title }} illustration">

--- a/js/search.js
+++ b/js/search.js
@@ -5,7 +5,7 @@ layout:
 (function() {
 
 var searchWorker;
-var searchURL = "{{ "/search/" | prepend: site.baseurl }}";
+var searchURL = "{{ "/search/" | relative_url }}";
 var replaceState = false;
 var replaceStateTimeout;
 var searchBox = document.getElementById('search-box');
@@ -35,7 +35,7 @@ function search(searchTerm) {
   searchBox.setAttribute("value", searchTerm);
 
   if(!searchWorker) {
-    searchWorker = new Worker("{{ "/js/search_worker.js" | prepend: site.baseurl }}");
+    searchWorker = new Worker("{{ "/js/search_worker.js" | relative_url }}");
 
     searchWorker.addEventListener("message", function(e) {
       displaySearchResults(e.data);

--- a/js/search_worker.js
+++ b/js/search_worker.js
@@ -3,7 +3,7 @@ layout:
 ---
 // http://jekyll.tips/jekyll-casts/jekyll-search-using-lunr-js/
 
-importScripts("{{ "/js/lunr.min.js" | prepend: site.baseurl }}");
+importScripts("{{ "/js/lunr.min.js" | relative_url }}");
 
 var store = {
 {% for article in site.articles %}


### PR DESCRIPTION
When you fork this repo and push a commit to the `gh-pages` branch, it will get rendered on `yourname.github.io/open-source-guide`. This fixes it so the page renders properly on forks.

I'd like to update the PR guidelines to ask people to include a link to their changes so we can preview them without having to build the site locally.