### PR TITLE
Docs: fix a small typo in the styleguide

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -15,7 +15,7 @@ All written content should follow these principles:
 * **Brevity:** Keep it simple, link to outside content for deeper dives
 * **Curation:** Amplify community best practices vs. any individual's point of view
 
-Content should maintain a light-hearted, but wise (think classy, not overly excited) tone. Open source is fun! Readers should inspired, not discouraged, by the tone of your writing, and they should trust you to help them get started.
+Content should maintain a light-hearted, but wise (think classy, not overly excited) tone. Open source is fun! Readers should feel inspired, not discouraged, by the tone of your writing, and they should trust you to help them get started.
 
 ## Mentions
 


### PR DESCRIPTION
This adds a missing word to a sentence in the styleguide docs.