### PR TITLE
Remove italics on blockquotes

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -7,7 +7,7 @@ img {
 }
 
 blockquote {
-  font-style: italic;
+  color: $gray;
   border-left: $border;
   border-width: 4px;
   padding: $spacer-1 0 0 $spacer-2;


### PR DESCRIPTION
This removes italics and lightens the text in block quotes.

cc @sophshep - do you have any strong feels about this?
cc @wooorm @hzoo
Fixes #308 

### Before


<img width="707" alt="starting_an_open_source_project_-_open_source_guide" src="https://cloud.githubusercontent.com/assets/173/23134829/d7f444e0-f75b-11e6-867f-e3626bffeda7.png">

…

<img width="704" alt="how_to_contribute_to_open_source_-_open_source_guide" src="https://cloud.githubusercontent.com/assets/173/23135017/8de86bdc-f75c-11e6-920b-9238e9fd2c6b.png">


### After

<img width="698" alt="starting_an_open_source_project_-_open_source_guide" src="https://cloud.githubusercontent.com/assets/173/23134959/576642fa-f75c-11e6-908d-726105d7bb86.png">

…

<img width="698" alt="how_to_contribute_to_open_source_-_open_source_guide" src="https://cloud.githubusercontent.com/assets/173/23135001/7b0b57ea-f75c-11e6-89bc-1e6c99528a9e.png">
