### PR TITLE
Change bundle update to bundle install

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,7 +5,7 @@ export CC=gcc
 
 echo "==> Installing gem dependencies…"
 bundle check --path vendor/gems 2>&1 > /dev/null || {
-  time bundle update --binstubs bin --path vendor/gems
+  time bundle install --binstubs bin --path vendor/gems
 }
 
 echo "==> Installing node dependencies…"


### PR DESCRIPTION
See: https://github.com/github/scripts-to-rule-them-all/blob/1eaa4de/script/bootstrap#L30-L32

I was getting an error message when running `script/bootstrap` that said that `--binstubs` and `--path` weren't recognized parameters. That's true for `bundle update` but not `bundle install`, so I double-checked against the Scripts To Rule Them All repo, made the change and things worked for me.