### PR TITLE
CONTRIBUTING: note linking policy.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Interested in making a contribution? Read on!
 Before we get started, here are a few things we expect from you (and that you should expect from others):
 
 * Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on "how open source is done." Try to listen to others rather than convince them that your way is correct.
+* If you're adding links to other resources please consider if they are going to be widely valuable. Similarly, please don't add links to things you or your employer have created as others will do so if they appreciate it.
 * Open Source Guides are released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms.
 * If you open a pull request, please ensure that your contribution passes all tests. If there are test failures, you will need to address them before we can merge your contribution.
 


### PR DESCRIPTION
Add a note to the contributing document to note some things to consider when adding links in a PR.