### PR TITLE
Remove jekyll-octicons plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages']
 
-gem 'jekyll-octicons'
 gem 'jekyll-seo-tag'
 
 group :test do

--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,6 @@ defaults:
 
 gems:
   - jekyll-mentions
-  - jekyll-octicons
   - jekyll-seo-tag
   - jekyll-sitemap
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,7 +43,14 @@
     </div>
 
     <div class="border-top text-gray py-5">
-      {% octicon code height:20 class:"v-align-middle fill-gray mr-1" aria-label:code %} with {% octicon heart height:20 class:"v-align-middle fill-gray mx-1" aria-label:love %} by <a href="https://github.com">{% octicon mark-github height:20 class:"v-align-middle fill-gray mx-1" aria-label:GitHub %}</a> <a href="https://github.com/github/open-source-guide/graphs/contributors" class="text-gray">(and you!)</a>
+      <svg height="20" class="octicon octicon-code v-align-middle fill-gray mr-1" aria-label="code" viewBox="0 0 14 16" version="1.1" width="17" role="img"><path d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
+      with
+      <svg height="20" class="octicon octicon-heart v-align-middle fill-gray mx-1" aria-label="love" viewBox="0 0 12 16" version="1.1" width="15" role="img"><path d="M11.2 3c-.52-.63-1.25-.95-2.2-1-.97 0-1.69.42-2.2 1-.51.58-.78.92-.8 1-.02-.08-.28-.42-.8-1-.52-.58-1.17-1-2.2-1-.95.05-1.69.38-2.2 1-.52.61-.78 1.28-.8 2 0 .52.09 1.52.67 2.67C1.25 8.82 3.01 10.61 6 13c2.98-2.39 4.77-4.17 5.34-5.33C11.91 6.51 12 5.5 12 5c-.02-.72-.28-1.39-.8-2.02V3z"></path></svg>
+      by
+      <a href="https://github.com">
+        <svg height="20" class="octicon octicon-mark-github v-align-middle fill-gray mx-1" aria-label="GitHub" viewBox="0 0 16 16" version="1.1" width="20" role="img"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
+      </a>
+      <a href="https://github.com/github/open-source-guide/graphs/contributors" class="text-gray">(and you!)</a>
     </div>
 
   </div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -30,7 +30,7 @@ layout: default
     <nav class="toc mb-4 mb-md-6">
       <div class="card col-sm-8 col-md-4 col-lg-3 mx-auto">
         <a class="toc-trigger d-block text-center p-3">
-          <span class="text-black">Table of Contents</span>{% octicon triangle-down height:18 class:"ml-2 fill-blue v-align-middle icon-flip" aria-label:open %}
+          <span class="text-black">Table of Contents</span><svg height="18" class="octicon octicon-triangle-down ml-2 fill-blue v-align-middle icon-flip" aria-label="open" viewBox="0 0 12 16" version="1.1" width="13" role="img"><path fill-rule="evenodd" d="M0 5l6 6 6-6z"></path></svg>
         </a>
         <ol class="toc-list list-style-none">
           {% for section in page.toc %}


### PR DESCRIPTION
When you push changes to the `gh-pages` branch on a fork:

>  Your site is having problems building: The tag `octicon` on line 29 in `/_layouts/article.html` is not a recognized Liquid tag. For more information, see https://help.github.com/articles/page-build-failed-unknown-tag-error/.

This plugin appears to only be whitelisted for GitHub staff, so this just replaces it with the `svg`s that it generates.

FYI: @parkr @benbalter not sure if there has been discussion about whitelisting this for everyone.
